### PR TITLE
adding filesystem checks, and os/kernel detection

### DIFF
--- a/gfetch.rc
+++ b/gfetch.rc
@@ -2,13 +2,31 @@
 # Warning, parts of this script have been STOLEN!
 
 # TODO:
-#   os type, labs/ants/front
-#   fs type
-#   fs usage/storage
-#   kernel
+# fs usage
+# kernel
 
+fn storage {
+	bind -b '#S' /dev
+	disks = `{ls -d /dev/sd* | uniq}
+	for(i in $disks){
+		if(test -f $i/data){
+			full = `{ls -l $i/data}
+			disk = `{echo $full | awk -F '/' '{print $3}'}
+			size = `{echo $full | awk '{print $6}'}
+			echo $disk^': '^`{echo $size^' / 1024 / 1024 /1024' | bc}^GB
+		}
+	}
+}
 
-os=9front
+os=`{
+	if(grep -s 'zrv' /dev/drivers)
+		echo 9ants
+	if not if(grep -s 'vmx' /dev/drivers)
+		echo 9front
+	if not
+		echo Bell Labs
+}
+arch=`{echo $cputype}
 shell=/bin/rc
 uptime=`{uptime| sed 's/.*up//; s/..........$//'}
 scr=`{dd -count 1 < /dev/screen|[2];}
@@ -17,14 +35,18 @@ ram=(`{tr / ' '</dev/swap})
 free=`{echo $ram(1)'/1024^2'|bc}
 used=`{echo '('$ram(3)'*('$ram(7)^+$ram(5)^'))/1024^2'|bc}
 cpu=`{aux/cpuid | grep procname | sed 's/.*procname//'}
+fs=`{ls /srv/*.cmd | sed 's/.cmd//g' | sed 's/\/srv\///g'}
+strg=`{storage}
 
 cat <<EOF
              $user@$sysname
     (\(\     -----------
-   j". ..    os: Plan 9 from $os
+   j". ..    os: Plan 9 from $os/$arch
    (  . .)   shell: $shell
    |   ° ¡   uptime: $uptime
    ¿     ;   ram: $used/$free MiB
    c?".UJ    cpu: $cputype $cpu 
              resolution: $scr
+             fs: $fs
+             $strg
 EOF


### PR DESCRIPTION
Can change the formatting on some things.

Tricky to split up 9legacy/labs detection, no detection for 9atom.

No fs usage as am not sure how to determine this without hostowner, all commands work as not hostowner.

No fs-disk pair as would require hostowner as above.
