### PR TITLE
Fix cpuid complaining about classified info on non-Intel systems

### DIFF
--- a/gfetch.rc
+++ b/gfetch.rc
@@ -39,7 +39,7 @@ fn fs {
 
 fn cpuid {
 	if(test -f /bin/aux/cpuid)
-		aux/cpuid | grep procname | sed 's/.*procname//'
+		aux/cpuid >[2]/dev/null | grep procname | sed 's/.*procname//'
 }
 
 os=`{


### PR DESCRIPTION
This will make `aux/cpuid` silent on systems that do not have the `cpuid` operation, which means systems that are not based on Intel architecture.

On arm64 (Raspberry Pi 3 Model B+), using `aux/cpuid` yields the following on console before `gfetch` runs:

```
aux/cpuid: this information is classified
```